### PR TITLE
Blowfish Encryption for User accounts!

### DIFF
--- a/android_connect/get_login.php
+++ b/android_connect/get_login.php
@@ -2,24 +2,35 @@
 
 	include_once('/../includes/db_connect.inc.php');
 
-	$stmt = $mysqli->prepare("SELECT COUNT(*) FROM users WHERE email = ? AND password = ?");
-	$stmt->bind_param('ss', $_GET['email'], $_GET['password']);
+	$stmt = $mysqli->prepare("SELECT password FROM users WHERE email = ?");
+	$stmt->bind_param('s', $_GET['email']);
 	$stmt->execute();
 	$result = $stmt->get_result();
 	$row = $result->fetch_row();
-
+	
 	header('Content-type: application/json');
-	if($row[0] == 0)
+	if(mysqli_num_rows($result) < 1)
 	{
-		$response["success"] = $row[0];
-		$response["message"] = "Login or password incorrect!";
+		$response["success"] = 0;
+		$response["message"] = "That email address is not registered!";
 		echo json_encode ( $response );
 	}
 	else
 	{
-		$response["success"] = $row[0];
-		$response["message"] = "Successful Login!";
-		echo json_encode ( $response );
+		
+		if(password_verify($_GET['password'], $row[0]))
+		{
+			$response["success"] = 1;
+			$response["message"] = "Successful Login!";
+			echo json_encode ( $response );
+		}
+		else
+		{
+			$response["success"] = 0;
+			$response["message"] = "Incorrect username or password!";
+			echo json_encode ( $response );
+		}
+		
 	}	
 
 	$mysqli->close();

--- a/android_connect/register_account.php
+++ b/android_connect/register_account.php
@@ -34,13 +34,25 @@
 	header('Content-type: application/json');
 	if($row[0] == 0)
 	{
+
+		$password_hash = password_hash($_POST['password'], PASSWORD_DEFAULT);
+		if($password_hash == false)
+		{
+			$result["success"] = 0;
+			$result["message"] = "Internal server problem!  Please inform admin.";
+			echo json_encode ( $result );
+			exit();
+		}
 		$stmt = $mysqli->prepare("INSERT INTO users(email, password, first, last) VALUES (?, ?, ?, ?)");
 		if($stmt === false)
 		{
-			echo "error in sql";
+			$result["success"] = 0;
+			$result["message"] = "Internal server problem!  Please inform admin.";
+			echo json_encode ( $result );
+			exit();
 		}
 
-		$stmt->bind_param('ssss', $_POST['email'], $_POST['password'], $_POST['first'], $_POST['last']);
+		$stmt->bind_param('ssss', $_POST['email'], $password_hash, $_POST['first'], $_POST['last']);
 		if($stmt->execute())
 		{
 			$result["success"] = 1;


### PR DESCRIPTION
I have updated registeraccount and getlogin php files to use PHP 5.5's
super duper ultra effective Bcrypt algorithm.  All passwords will now be
stored in 60 char hashes in the database and are also virtually immune
to rainbow table lookups.  No changes need to be made on the client
side, it's all ready to go!

Note: All user accounts with plain text passwords have been removed from
the user table.  please create new accounts for testing.  It is safe to
use a real password if you want because no one (including ourselves) can
view the password anymore! Hooray!
